### PR TITLE
feat(server): central onec-ops MCP в docker (команда) + Team-локализация

### DIFF
--- a/docs/deploy-center.md
+++ b/docs/deploy-center.md
@@ -156,3 +156,17 @@ cd "$SERVER_DIR" && docker compose up -d --build   # пересоберёт то
 - [ ] ШАГ 4: `docker compose up -d --build`; `ps` — proxy наружу, onec-code внутри, `/src` ro.
 - [ ] ШАГ 5: 401 без токена + осмысленный ответ smoke-клиента с токеном.
 - [ ] ШАГ 6: подключение роздано out-of-band; автообновление (если нужно) — read-only доступ + fail-safe.
+
+---
+
+## onec-ops (MCP эксплуатации) — поднимается тем же compose
+
+Стек `server/` теперь поднимает ДВА MCP за одним Caddy (bearer-auth): `onec-code` (`:8000`, чтение кода) и
+**`onec-ops`** (`:8001`, эксплуатация — ТЖ/ЖР/Apdex/диагностика/Zabbix/Prometheus, read-only).
+- В `.env` добавь: `ONEC_TJ_DIR` (каталог логов ТЖ/выгрузок ЖР, монтируется read-only), при необходимости
+  `ONEC_OPS_PUBLIC_PORT` (по умолч. 8001) и адаптеры `ZABBIX_URL/ZABBIX_TOKEN`, `PROMETHEUS_URL`.
+- `docker compose up -d --build` поднимает оба; `docker compose ps` → `onec-code`, `onec-ops`, `proxy`.
+- Разработчик подключается к `onec-ops` на `:8001` с тем же bearer-токеном (см. `connect.md`).
+- Проверка локально без docker: `MCP_TRANSPORT=sse MCP_PORT=8001 python mcp/onec_ops_mcp.py` → отдаёт SSE на `/sse`.
+
+Team-локализация (org-конфиги/секреты поверх ядра из GitHub, без дублирования) — `team-localization-template.md`.

--- a/docs/team-localization-template.md
+++ b/docs/team-localization-template.md
@@ -1,0 +1,62 @@
+# Team-локализация (org-слой поверх toolkit) — шаблон/runbook
+
+Как развернуть toolkit В КОМАНДЕ под конкретную организацию, **не дублируя ядро**: Team-репозиторий —
+тонкий слой, который ПОДТЯГИВАЕТ `claude-1c-toolkit` из GitHub и добавляет только org-специфичное
+(конфиги контуров, пути, секреты). Ядро (скиллы, MCP, server-стек) — НЕ копировать.
+
+> Где живёт Team-репо: на **корпоративном** Git (напр. внутренний GitLab), НЕ на публичном GitHub —
+> он содержит org-данные (карта баз/контуров) и не должен утекать. Публичный toolkit остаётся обезличенным.
+
+## Структура Team-репо (минимум)
+```
+<org>-1c-toolkit-team/
+├── toolkit/                      # git submodule → https://github.com/<owner>/claude-1c-toolkit (ядро, pin по тегу)
+├── config/
+│   ├── layers.<org>.toml         # слои/контуры ОРГАНИЗАЦИИ (какие репо = конфигурация, какие = расширения)
+│   └── contours.<org>.md         # карта баз/контуров (ORG-ДАННЫЕ — только здесь, не в ядро)
+├── server/
+│   └── .env                      # секреты/пути ОРГ (вне git: .gitignore) — ONEC_SRC_DIR, токен, ONEC_TJ_DIR, Zabbix/Prometheus
+├── CLAUDE.md                     # org-оверрайды правил (версии платформы/совместимости/конфигурации)
+└── README.md                     # как обновлять submodule, как поднимать центр
+```
+
+## Шаги (runbook для Claude/инженера — выполнять НА корп-стороне)
+1. **Создать Team-репо** на корп-Git. Подключить ядро как submodule (pin по тегу/релизу, обновлять осознанно):
+   ```bash
+   git submodule add https://github.com/<owner>/claude-1c-toolkit toolkit
+   git -C toolkit checkout <tag>          # зафиксировать версию ядра
+   ```
+2. **Заполнить org-конфиги** (это и есть «адаптация под организацию»):
+   - `config/layers.<org>.toml` ← по образцу `toolkit/config/layers.example.toml`: реальные репозитории
+     конфигурации/расширений, префиксы, scope-группы, профили (страновые/контурные).
+   - `config/contours.<org>.md` ← по образцу `toolkit/config/contours.example.md`: карта «какая база с чем
+     вяжется», риски переноса, слепые зоны. **ORG-данные — не в публичный toolkit.**
+   - `toolkit/skills/1c-dev/references/conventions-template.md` НЕ править в submodule — конвенции вынести в
+     свой слой/`CLAUDE.md`, иначе потеряются при обновлении ядра.
+3. **server/.env** (секреты, вне git) — по `toolkit/server/.env.example`:
+   - `ONEC_SRC_DIR` — реальный каталог клонов кода 1С;
+   - `ONEC_BEARER_TOKEN` — `openssl rand -hex 32`;
+   - `ONEC_TJ_DIR` — каталог логов ТЖ/выгрузок ЖР для onec-ops;
+   - `ZABBIX_URL/ZABBIX_TOKEN`, `PROMETHEUS_URL` — если используются (read-only).
+4. **Поднять центр в корп-docker** (на корп-хосте с Docker; runbook — `toolkit/docs/deploy-center.md`):
+   ```bash
+   cd toolkit/server
+   docker compose --env-file ../../server/.env up -d --build
+   docker compose ps      # onec-code:8000 и onec-ops:8001 за Caddy bearer-auth
+   ```
+5. **Разработчики подключаются** к центру по HTTP (SSE) с bearer-токеном (см. `toolkit/docs/connect.md`):
+   onec-code — `:8000`, onec-ops — `:8001`. Локально код/логи не клонируют — берут с центра.
+
+## Что адаптируется под организацию (и где помечается)
+| Что | Где (Team-слой) | НЕ в публичном ядре |
+| --- | --- | --- |
+| Карта баз/контуров, какие репо = конфигурация/расширения | `config/layers.<org>.toml`, `config/contours.<org>.md` | да — обезличено |
+| Версии платформы/совместимости/конфигурации | `CLAUDE.md` (org) | да |
+| Реальные пути (код, логи ТЖ/ЖР), хост docker | `server/.env` (вне git) | да |
+| Секреты (bearer, Zabbix-токен) | `server/.env` / секрет-стор | НИКОГДА в git |
+| URL мониторинга (Zabbix/Prometheus) | `server/.env` | да |
+
+## Принцип обновления
+Улучшения/фиксы — **в ядро** `claude-1c-toolkit` (PR на GitHub), затем в Team `git submodule update --remote` +
+смена тега. Никогда не форкать ядро под org-правки — только слой поверх. Так Team всегда получает свежее ядро,
+а org-специфика остаётся изолированной.

--- a/mcp/onec_ops_mcp.py
+++ b/mcp/onec_ops_mcp.py
@@ -518,7 +518,10 @@ def event_log_parse(source, level=None, user=None, events=None, top=100, table=N
 # --- MCP-обёртка (read-only) ---
 try:
     from mcp.server.fastmcp import FastMCP
-    mcp = FastMCP("onec-ops")
+    # host/port для сетевого транспорта (sse/streamable-http) при центральном развёртывании в docker
+    mcp = FastMCP("onec-ops",
+                  host=os.environ.get("MCP_HOST", "0.0.0.0"),
+                  port=int(os.environ.get("MCP_PORT", "8001")))
 
     @mcp.tool()
     def tech_journal_parse(roots, events=None, min_duration: int = 0,
@@ -585,6 +588,7 @@ try:
         return prometheus_query(base_url, query)
 
     if __name__ == "__main__":
-        mcp.run()
+        # транспорт: stdio (по умолчанию, для локального Claude Code) | sse | streamable-http (для docker-центра)
+        mcp.run(transport=os.environ.get("MCP_TRANSPORT", "stdio"))
 except ImportError:  # pragma: no cover — модуль остаётся импортируемым без пакета mcp (для тестов парсера)
     mcp = None

--- a/server/.env.example
+++ b/server/.env.example
@@ -17,3 +17,13 @@ ONEC_PUBLIC_PORT=8000
 
 # (необязательно) Активный профиль/режим из конфига слоёв (секция [profiles.<имя>]).
 # ONEC_PROFILE=rb
+
+# --- onec-ops (MCP эксплуатации: ТЖ/ЖР/Apdex/диагностика/Zabbix/Prometheus) ---
+# Порт onec-ops наружу (через Caddy, та же bearer-аутентификация). По умолчанию 8001.
+ONEC_OPS_PUBLIC_PORT=8001
+# Каталог(и) логов 1С (технологический журнал / выгрузки ЖР) на хосте — read-only вход onec-ops.
+ONEC_TJ_DIR=/path/to/1c-logs
+# (необязательно) Адаптеры мониторинга — read-only доступ; ПУСТО = выключено. Секреты только здесь, не в git.
+# ZABBIX_URL=https://zabbix.example/api_jsonrpc.php
+# ZABBIX_TOKEN=
+# PROMETHEUS_URL=http://prometheus.example:9090

--- a/server/Dockerfile.ops
+++ b/server/Dockerfile.ops
@@ -1,0 +1,16 @@
+# Центральный MCP ЭКСПЛУАТАЦИИ 1С (onec-ops) как HTTP-сервис (для команды/нескольких разработчиков).
+# Read-only инструменты: разбор ТЖ/ЖР, Apdex, диагностика по порогам, опц. Zabbix/Prometheus.
+# Каталог(и) логов 1С (ТЖ/ЖР) монтируются томом read-only; сервис отдаёт MCP по HTTP (SSE).
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir "mcp>=1.2" openpyxl
+
+WORKDIR /app
+COPY mcp/onec_ops_mcp.py /app/onec_ops_mcp.py
+
+ENV MCP_TRANSPORT=sse \
+    MCP_HOST=0.0.0.0 \
+    MCP_PORT=8001
+
+EXPOSE 8001
+CMD ["python", "/app/onec_ops_mcp.py"]

--- a/server/caddy/Caddyfile
+++ b/server/caddy/Caddyfile
@@ -23,3 +23,18 @@
 		}
 	}
 }
+
+# Параллельный вход для onec-ops (MCP эксплуатации), та же bearer-аутентификация.
+:8001 {
+	@unauthorized not header Authorization "Bearer {$ONEC_BEARER_TOKEN}"
+
+	handle @unauthorized {
+		respond "401 Unauthorized" 401
+	}
+
+	handle {
+		reverse_proxy onec-ops:8001 {
+			flush_interval -1
+		}
+	}
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -24,12 +24,35 @@ services:
       ONEC_PROFILE: "${ONEC_PROFILE:-}"
     restart: unless-stopped
 
+  onec-ops:
+    # MCP эксплуатации 1С (read-only: ТЖ/ЖР/Apdex/диагностика/Zabbix/Prometheus). Контекст сборки — корень репо.
+    build:
+      context: ..
+      dockerfile: server/Dockerfile.ops
+    image: claude-1c-toolkit/onec-ops:latest
+    expose:
+      - "8001"            # только внутренняя сеть compose, на хост не публикуется (наружу — через proxy)
+    volumes:
+      # Каталог(и) логов 1С (ТЖ/ЖР) — read-only. Путь org-specific, задаётся в .env (Team-слой).
+      - "${ONEC_TJ_DIR:-../logs}:/logs:ro"
+    environment:
+      MCP_TRANSPORT: sse
+      MCP_HOST: 0.0.0.0
+      MCP_PORT: "8001"
+      # Опциональные адаптеры мониторинга (org-specific, задаются в .env Team-слоя). Пусто = выключено.
+      ZABBIX_URL: "${ZABBIX_URL:-}"
+      ZABBIX_TOKEN: "${ZABBIX_TOKEN:-}"
+      PROMETHEUS_URL: "${PROMETHEUS_URL:-}"
+    restart: unless-stopped
+
   proxy:
     image: caddy:2-alpine
     depends_on:
       - onec-code
+      - onec-ops
     ports:
       - "${ONEC_PUBLIC_PORT:-8000}:8000"
+      - "${ONEC_OPS_PUBLIC_PORT:-8001}:8001"
     volumes:
       - "./caddy/Caddyfile:/etc/caddy/Caddyfile:ro"
     environment:


### PR DESCRIPTION
## Что
Центральное развёртывание MCP эксплуатации **onec-ops** в docker для общего доступа разработчиков (как уже сделано для onec-code).

- onec_ops_mcp.py — сетевой транспорт (MCP_TRANSPORT=sse + host/port). Проверено: Uvicorn SSE /sse → HTTP 200.
- server/: Dockerfile.ops + сервис onec-ops (expose 8001, том логов read-only, env Zabbix/Prometheus) + Caddy :8001 (bearer-auth) + .env.example.
- docs/deploy-center — секция onec-ops; docs/team-localization-template — org-слой тянет ядро из GitHub (submodule), без дублирования; org-данные/секреты только в Team-слое.

## Контур
Публичное ядро остаётся generic/обезличенным. Реальный `docker compose up` в корп-docker и Team-репо на корп-GitLab — на корп-стороне (Mac↔corp изолированы). Здесь — generic-артефакты + runbook.

## Проверка
32/32 теста; локальный запуск onec-ops по SSE подтверждён (HTTP 200 /sse); YAML compose валиден; скан секретов/корп/атрибуции — чисто.