### PR TITLE
scripts: UTF-8 stdout/stderr — не падать на cp1251-консоли Windows

### DIFF
--- a/scripts/apdex_to_zabbix.py
+++ b/scripts/apdex_to_zabbix.py
@@ -20,6 +20,13 @@ import os
 import subprocess
 import sys
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "mcp"))
 import onec_ops_mcp as ops  # noqa: E402
 

--- a/scripts/atlassian.py
+++ b/scripts/atlassian.py
@@ -30,6 +30,13 @@ import sys
 import urllib.parse
 import urllib.request
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "mcp"))
 try:
     import onec_ops_mcp as _ops

--- a/scripts/designer_sync.py
+++ b/scripts/designer_sync.py
@@ -34,6 +34,13 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))                      # detect_tools рядом
 sys.path.insert(0, str(SCRIPTS_DIR.parent / "mcp"))       # load_dotenv_defaults

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -14,6 +14,13 @@
 import os, shutil, subprocess, sys
 from pathlib import Path
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 MARKER = "claude-no-coauthor"
 SRC = Path(__file__).resolve().parent / "git-hooks"
 

--- a/scripts/storage_map.py
+++ b/scripts/storage_map.py
@@ -34,6 +34,13 @@ import sys
 import time
 from pathlib import Path
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 STALE_DAYS = 90  # конфигурация живая: карта старше — вероятно, отстала от реструктуризаций
 
 _HEADER_HINTS = ("имя таблицы", "метаданные", "назначение", "storage", "table name")

--- a/scripts/switch_source.py
+++ b/scripts/switch_source.py
@@ -20,6 +20,13 @@
 import argparse, json, os, socket, sys
 from urllib.parse import urlparse
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 

--- a/scripts/zabbix_perf.py
+++ b/scripts/zabbix_perf.py
@@ -23,6 +23,13 @@ import json
 import os
 import sys
 
+# Windows-консоль по умолчанию cp1251 — печать '→'/'—'/кириллицы роняет скрипт. Принудительно UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "mcp"))
 import onec_ops_mcp as ops  # noqa: E402
 


### PR DESCRIPTION
Фикс `UnicodeEncodeError` на дефолтной Windows-консоли (cp1251/cp866): символы вне кодировки (`→`/`—`/`⚠`) в сообщениях роняли `print`.

Критично для `switch_source.py --mode auto` — падение шло **до** записи `.mcp.json`, т.е. переключение onec-code (local/central) не срабатывало вовсе.

Добавлен guard `reconfigure(encoding="utf-8", errors="replace")` в начало каждого затронутого CLI — в том же стиле, что уже применён в `detect_tools.py`.

Затронуто 7 скриптов: `switch_source`, `apdex_to_zabbix`, `zabbix_perf`, `atlassian`, `designer_sync`, `storage_map`, `install_git_hooks`. Только stdlib, кроссплатформенно, на не-Windows `reconfigure` уже UTF-8 — поведение не меняется.