### PR TITLE
fix(apply): SSH-раннер декодирует вывод как UTF-8, а не локальной cp1251

### DIFF
--- a/onec_metadata/apply/runner.py
+++ b/onec_metadata/apply/runner.py
@@ -81,10 +81,16 @@ class Runner:
         self.host = host
 
     def run(self, cmd: str, timeout: int = 600):
+        # encoding+errors ОБЯЗАТЕЛЬНЫ: text=True без encoding декодирует вывод ssh
+        # локальной кодировкой Windows (cp1251), а файл-результат/лог платформа отдаёт
+        # в UTF-8 (read_text тянет его через `chcp 65001 & type`). На кириллице это
+        # роняло `UnicodeDecodeError: 'charmap' codec` уже ПОСЛЕ успешного прогона.
+        # errors="replace" — служебные команды (whoami/ver) редко, но бывают не-UTF-8.
         with _masked(cmd, timeout):
             p = subprocess.run(
                 ["ssh", "-o", "BatchMode=yes", self.host, cmd],
-                capture_output=True, text=True, timeout=timeout)
+                capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=timeout)
         return p.returncode, (p.stdout + p.stderr)
 
     def put(self, local, remote: str, timeout: int = 300):


### PR DESCRIPTION
## Проблема

`Runner.run` (SSH-транспорт в `onec_metadata/apply/runner.py`) читал вывод `ssh` с `text=True` **без** `encoding=`. Python декодировал его локальной кодировкой Windows (на русской локали — cp1251/`charmap`). А файл-результат и лог платформа отдают в **UTF-8** (`read_text` тянет их через `chcp 65001 & type`).

На кириллице это роняло прогон **уже после УСПЕШНОГО выполнения** — при вычитывании результата:

```
UnicodeDecodeError: 'charmap' codec can't decode byte ... 
```

а следом вторичный `TypeError: NoneType + str` в вызывающем коде. Практическое следствие: смоук-результат приходилось забирать вручную через `ssh ... | base64 -d`.

## Фикс

Одна точка — `subprocess.run` SSH-раннера получает явную кодировку:

```python
capture_output=True, text=True,
encoding="utf-8", errors="replace", timeout=timeout
```

`read_text` уже ставит `chcp 65001`, поэтому вывод — UTF-8 и декодируется корректно. `errors="replace"` страхует служебные команды (`whoami`/`ver`), которые изредка бывают не-UTF-8, — они больше не роняют процесс.

## Проверка

- `py_compile` чистый.
- Живой Windows-терминал по SSH: `put` UTF-8-файла с кириллицей → `read_text` возвращает строку без падения, UTF-8-байты совпадают с исходником (`__SMOKE_OK__ Проверка кодировки кириллица UTF-8`).
