### PR TITLE
pre-push: не вызывать внешний sh (падало при push из EDT)

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -20,7 +20,14 @@
 
 REPO_HOOK="scripts/hooks/pre-push"
 if [ -f "$REPO_HOOK" ]; then
-    sh "$REPO_HOOK" "$@" </dev/null || exit 1
+    # НЕ вызываем внешний `sh`: EDT/EGit запускает хуки с урезанным PATH, где его нет — реальный
+    # случай, push из EDT падал с "line 23: sh: command not found". Исполняемый файл запускаем
+    # напрямую (шебанг разрешается по абсолютному пути), иначе — в подоболочке, без поиска в PATH.
+    if [ -x "$REPO_HOOK" ]; then
+        "$REPO_HOOK" "$@" </dev/null || exit 1
+    else
+        ( . "$REPO_HOOK" ) </dev/null || exit 1
+    fi
 fi
 
 if command -v git-lfs >/dev/null 2>&1; then

--- a/tests/test_install_git_hooks.py
+++ b/tests/test_install_git_hooks.py
@@ -102,3 +102,16 @@ def test_lfs_usage_detection(tmp_path):
     with_lfs = _init_repo(tmp_path / "lfs", "*.bin filter=lfs diff=lfs merge=lfs -text\n")
     assert _repo_uses_lfs(without) is False, "в репозитории без LFS хук обязан пропускать push"
     assert _repo_uses_lfs(with_lfs) is True, "в репозитории с LFS хук обязан требовать git-lfs"
+
+
+def test_no_external_sh_lookup():
+    """Хук не должен вызывать внешний `sh`: EDT/EGit даёт урезанный PATH, где его нет.
+
+    Реальный случай: push из EDT падал с "sh: command not found". Репо-хук запускаем напрямую
+    (исполняемый) либо в подоболочке — оба варианта не требуют поиска интерпретатора в PATH.
+    """
+    ours = (SCRIPTS_DIR / "git-hooks" / "pre-push").read_text(encoding="utf-8")
+    code = [ln for ln in ours.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any(ln.strip().startswith("sh ") or " sh " in ln for ln in code),         "вызов внешнего sh в хуке — он не находится в окружении EDT"
+    assert '"$REPO_HOOK" "$@"' in ours, "исполняемый репо-хук должен запускаться напрямую"
+    assert '( . "$REPO_HOOK" )' in ours, "нужен фолбэк через подоболочку для неисполняемого файла"


### PR DESCRIPTION
EDT/EGit запускает git-хуки с урезанным окружением, где `sh` не находится в PATH. Делегирование в репо-хук было написано как `sh "$REPO_HOOK"`, и push из EDT падал: "Can't connect to any repository: ...hooks/pre-push: line 23: sh: command not found".

Теперь исполняемый репо-хук запускается напрямую (шебанг разрешается по абсолютному пути, поиск в PATH не нужен), а неисполняемый — в подоболочке через точку. Оба варианта не требуют внешнего интерпретатора.

Добавлен регрессионный тест test_no_external_sh_lookup: в коде хука не должно быть вызова `sh`, и должны присутствовать оба способа запуска. 8/8 тестов проходят.

Найдено на реальном использовании в erpwe-all-ext-core-common. Там же вскрылись две смежные вещи, уже поправленные на стороне репозитория: хук выкладывался с CRLF (шебанг "#!/bin/sh\r") — правило eol=lf для scripts/hooks/** в этом PR уже есть; и в окружении EDT нет python, из-за чего проверка молча пропускалась — репо-хук теперь ищет интерпретатор по абсолютным путям и при неудаче останавливает push.

<!-- Спасибо за вклад! Люди и AI-агенты — оба приветствуются. -->

## Что и зачем
<!-- Кратко: что меняет PR и какую боль/задачу закрывает. -->

## Тип
- [ ] Правило/скилл (по реальному коду 1С, со ссылкой на справку/исходники)
- [ ] Проверка (bsl_guard / гейт / round-trip) + фикстура + тест
- [ ] Движок метаданных `onec_metadata` (+ round-trip-тест)
- [ ] Адаптер под нового AI-агента
- [ ] Документация
- [ ] Onboard / build / CI

## Чек-лист (обязательно)
- [ ] Правил `core/`, не сгенерированное; выполнил `sh build.sh` — конфиги пересобраны
- [ ] `pytest tests/ -q` → всё зелёное (и мои новые тесты)
- [ ] Новая проверка сопровождается фикстурой и тестом
- [ ] Факты о 1С — со ссылкой (не «по памяти»); непроверенное помечено `[проверить]`
- [ ] Без секретов, ПДн и данных конкретных организаций (обезличено)
- [ ] Стиль: без жаргона, по-русски, «заголовок = вывод»

## Ссылки
<!-- Справка платформы/БСП / исходники / issue, которое закрывает. -->
